### PR TITLE
Add: pricing to store array

### DIFF
--- a/src/options/optionsSlice.js
+++ b/src/options/optionsSlice.js
@@ -48,6 +48,18 @@ const initialState = {
       id: 7,
     },
   ],
+  price: [
+    {
+      toppings: '1'
+    },
+    {
+      size: {
+      small: 10,
+      medium: 13,
+      large: 16
+      }
+    }
+  ],
 };
 
 const optionsSlice = createSlice({


### PR DESCRIPTION
### Description

This pull request will add pricing to the store array and initialize the prices.  Currently we are only adding the pricing for toppings and sizes. We may wish to discuss this further in the future, but I think excluding options from the array, such as `crusts` will allow us to check if the pricing options exists in the table, and skip base on whether it is there or not. 